### PR TITLE
Fix duplication on field name

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,7 +2,7 @@
 
 backend:
   name: git-gateway
-  branch: master # Branch to update (optional; defaults to master)
+  branch: main # Branch to update (optional; defaults to master)
 media_folder: "assets/uploads"
 collections:
   - name: "blog"
@@ -55,7 +55,7 @@ collections:
             }
           - {
               label: "Layout",
-              name: "title",
+              name: "layout",
               widget: "hidden",
               default: "about",
             }


### PR DESCRIPTION
There's a minor bug in the admin panel config which blocks the admin ui from appearing "out of the box" - I believe this path fixes it.
Replaces #2